### PR TITLE
Makes scripts return a failure exit code on error.

### DIFF
--- a/bin/recursive-copy
+++ b/bin/recursive-copy
@@ -8,5 +8,6 @@ var destination = path.resolve(process.cwd(), process.argv[3])
 recursive.cpdirr(source, destination, function (err) {
   if (err) {
     console.error(err)
+    process.exit(1)
   }
 })

--- a/bin/recursive-delete
+++ b/bin/recursive-delete
@@ -7,5 +7,6 @@ var folder = path.resolve(process.cwd(), process.argv[2])
 recursive.rmdirr(folder, function (err) {
   if (err && err.code !== 'ENOENT') {
     console.error(err)
+    process.exit(1)
   }
 })


### PR DESCRIPTION
When an error occurs during the `recursive-copy` or `recursive-delete` script, it should propagate that error up to the calling shell so it can branch on it.  For example, in `recrusive-copy source/foo destination/foo && ./destination/foo/script.js` the second command should not execute if the first command fails.  Right now, the first command will fail but return a 0 exit code, resulting in the following command attempting to run (and possibly failing).