### PR TITLE
Use path.join() instead of hardcoding forward slash on path

### DIFF
--- a/lib/read.js
+++ b/lib/read.js
@@ -1,5 +1,6 @@
 
 var fs = require('fs')
+var path = require('path')
 
 
 function async (dpath, done) {
@@ -16,7 +17,7 @@ function async (dpath, done) {
         if (err) return done(err)
 
         for (var entry of _files) {
-          var fpath = `${dir}/${entry.name}`
+          var fpath = path.join(dir, entry.name)
           if (entry.isDirectory()) {
             __dirs.push(fpath)
             dirs.push(fpath)
@@ -47,7 +48,7 @@ function sync (dpath) {
       var _files = fs.readdirSync(dir, {withFileTypes: true})
 
       for (var entry of _files) {
-        var fpath = `${dir}/${entry.name}`
+        var fpath = path.join(dir, entry.name)
         if (entry.isDirectory()) {
           __dirs.push(fpath)
           dirs.push(fpath)

--- a/lib/size.js
+++ b/lib/size.js
@@ -5,7 +5,6 @@ var fs = require('fs')
 function async (files, done) {
   var size = 0
   var limit = 100
-  var complete = 0
 
   ;(function walk (offset, _files) {
     if (!_files.length) return done(null, size)


### PR DESCRIPTION
This change exchanges the hardcoded `/` with `path.join()` to produce more correct paths on Windows